### PR TITLE
Fixed #34, but affected util methods

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -149,8 +149,18 @@
 	}
 	
 	function processText(text) {
-		text = xv_utils.escapeHTML(xv_utils.trim(text));
-		return xv_utils.findURLs(text);
+		var urls = xv_utils.findURLs(xv_utils.trim(text));
+
+		var result = _.map(urls, function (text, i) {
+			// odd elements are urls
+			if (i % 2 === 1) {
+				return xv_utils.formatURL(text);
+			} else {
+				return xv_utils.escapeHTML(text);
+			}
+		});
+
+		return result.join('');
 	}
 	
 	/**

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,20 +120,28 @@ var xv_utils = (function(){
 		},
 		
 		/**
-		 * Finds URLs inside text and wraps it with &lt;a&gt; tag
+		 * Splits text into array with URLs in odd positions
+		 * @param {String} text
+		 * @returns {Array}
+		 */
+		findURLs: function(text) {
+			var reDelim = new RegExp('(' + reURL.source + ')', 'ig');
+			return text.split(reDelim);
+		},
+
+		/**
+		 * Formats URL as link with sanitized URL and text
 		 * @param {String} text
 		 * @returns {String}
 		 */
-		findURLs: function(text) {
-			return text.replace(reURL, function(url) {
-				// has protocol?
-				var href = url;
-				if (!/^[a-z]+:\/\//i.test(href)) {
-					href = 'http://' + href;
-				}
-				
-				return '<a href="' + href + '" class="xv-url">' + url + '</a>';
-			});
+		formatURL: function(url) {
+			// has protocol?
+			var href = url;
+			if (!/^[a-z]+:\/\//i.test(href)) {
+				href = 'http://' + href;
+			}
+
+			return '<a href="' + href + '" class="xv-url">' + this.escapeHTML(url) + '</a>';
 		}
 	};
 })();


### PR DESCRIPTION
I completely changed findURLs function, but it seems to be used only in processText, so I considered it would be ok.

Now in processText findURLs splits text into chunks, then formats even (text) chunks  with xv_utils.escapeHTML and odd (link) chunks with xv_utils.formatURL, which formats anchor and escapes text too.
