### PR TITLE
Add support for WebAPI feeds in Chrome

### DIFF
--- a/extensions/chrome/controller.js
+++ b/extensions/chrome/controller.js
@@ -190,6 +190,7 @@ function renderPage(url) {
 	};
 	
 	xhr.open("GET", url || document.URL, true);
+	xhr.setRequestHeader("Accept", "application/xml,application/xhtml+xml,text/html;q=0.8,*/*;q=0.7");
 	xhr.send();
 }
 


### PR DESCRIPTION
Send Accepts header through in Chrome to ensure correct response type is returned where applicable

This forces Microsoft WebAPI feeds, and any others that obey the Accepts header, to return XML as opposed to JSON, CSV, etc where available.

The header almost matches that which chrome sends by default, with the various format weightings re-arranged to give preference to XML over HTML before finally falling back to whatever format is available (*.*)