### PR TITLE
Fix Issue #68 - Scroll not working

### DIFF
--- a/src/outline_ui.js
+++ b/src/outline_ui.js
@@ -37,6 +37,7 @@
 			// normal browser – just update style
 			xv_dom.setCSS(pane, {width: width});
 			xv_dom.setCSS(source_pane, {right: width});
+			xv_dom.setCSS(source_pane, {height: (window.innerHeight - 37 + 1)});
 		} else {
 			// Freakin' crazy way to update XML element style:
 			// modify document’s stylesheet with new rules.


### PR DESCRIPTION
#68 Weird scroll problem in chrome, weirder fix.
Only way to fix the scroll issue is to allow overflow on body. To keep the overflow at its minimum, I've set the source pane's height to inner height - 37 (37px is the fixed height of the search bar).
Then added 1 px to trigger the overflow. This allows scrolling the source pane in case the xml is too long.